### PR TITLE
Fix panic on cache parse

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -2,7 +2,7 @@ use endian_trait::Endian;
 
 use crate::{
     consts::*,
-    error::{MzResult, MzError},
+    error::{MzError, MzResult},
 };
 
 use core::slice;
@@ -180,8 +180,7 @@ pub fn parse_cachefile(data: &Vec<u8>) -> MzResult<CacheFile> {
             }
             unsafe { buff.set_len(hash_count * 2) }
             buff
-        }
-        else {
+        } else {
             Vec::<u8>::new()
         }
     };
@@ -214,7 +213,7 @@ fn parse_chunks(data_buff: &[u8]) -> io::Result<Vec<u8>> {
                 ))
             }
         };
-        if chunk_buf[0..2] == b"\x1F\x8B".to_vec() {
+        if chunk_buf.len() >= 2 && chunk_buf[0..2] == b"\x1F\x8B".to_vec() {
             let mut plain_buf = decopres_chunk(chunk_buf)?;
             chunks.append(&mut plain_buf);
         } else {
@@ -256,7 +255,9 @@ mod tests {
         let fetched = h.last_fetched_time.0 as u64;
 
         // is not form last year
-        if ((modified > now || modified < (now - year)) || (fetched > now || fetched < (now - year))) && modified >= fetched
+        if ((modified > now || modified < (now - year))
+            || (fetched > now || fetched < (now - year)))
+            && modified >= fetched
         {
             // is not a specila value
             if modified > 10 && fetched > 10 {


### PR DESCRIPTION
I was getting a panic when I ran the CLI, specifically when using a cache from the Zen fork of Firefox, this was the backtrace for it:

```logs
thread 'main' (920083) panicked at src/file.rs:217:21:
range end index 2 out of range for slice of length 1
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:698:5
   1: core::panicking::panic_fmt
             at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panicking.rs:75:14
   2: core::slice::index::slice_index_fail::do_panic::runtime
             at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panic.rs:173:21
   3: core::slice::index::slice_index_fail
             at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panic.rs:178:9
   4: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /home/joshf/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:438:13
   5: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /home/joshf/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:18:15
   6: mzcache2::file::parse_chunks
             at ./src/file.rs:217:21
   7: mzcache2::file::parse_cachefile
             at ./src/file.rs:193:18
   8: mzcache2::parse::parse_enries
             at ./src/parse.rs:39:27
   9: mzcache2::parse::parse_cache_folder
             at ./src/parse.rs:23:16
  10: mzcache2::main
             at ./src/main.rs:27:28
  11: core::ops::function::FnOnce::call_once
             at /home/joshf/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Please correct me if this breaks the parsing, but the output looked correct to me after running it with the changes.

Thanks for all your work with this.